### PR TITLE
fix(filesystem): robust minimatch interop and test fixes

### DIFF
--- a/src/filesystem/path-utils.ts
+++ b/src/filesystem/path-utils.ts
@@ -117,6 +117,10 @@ export function fileUriToPath(uri: string): string {
       }
       // convert forward slashes to backslashes
       p = p.replace(/\//g, '\\');
+      // Ensure drive letter is capitalized for consistency (tests expect uppercase drive)
+      if (/^[a-z]:\\/.test(p)) {
+        p = p.charAt(0).toUpperCase() + p.slice(1);
+      }
     }
     return p;
   } catch {


### PR DESCRIPTION
Apply runtime-robust minimatch interop, fix file URI decoding for Windows drive letters, and guard runtime init so tests can import schemas. Builds & tests pass locally.